### PR TITLE
Sorted workspaces + messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vercel

--- a/.vercel/README.txt
+++ b/.vercel/README.txt
@@ -1,0 +1,11 @@
+> Why do I have a folder named ".vercel" in my project?
+The ".vercel" folder is created when you link a directory to a Vercel project.
+
+> What does the "project.json" file contain?
+The "project.json" file contains:
+- The ID of the Vercel project that you linked ("projectId")
+- The ID of the user or team your Vercel project is owned by ("orgId")
+
+> Should I commit the ".vercel" folder?
+No, you should not share the ".vercel" folder with anyone.
+Upon creation, it will be automatically added to your ".gitignore" file.

--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,0 +1,1 @@
+{"projectId":"QmX8mmqfiVe3RNrgFfRYz1cgQLE84AujqH3Qqus3P9ynVb","orgId":"UODsPhvqp4RGnBQNblf4BlGb"}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,8 @@ const App: React.FC = () => {
 
   const initValues = useLocalStorageEarthstarSettings("lobby");
 
+  console.log("rendered");
+
   return (
     // Pass a theme into the app for styled components to use.
     <ThemeProvider theme={makeThemeForFont("Gill Sans", theme || lightTheme)}>

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -3,11 +3,12 @@ import { css } from "styled-components/macro";
 import WorkspaceSummary from "./WorkspaceSummary";
 import { useStorages } from "react-earthstar";
 import { IStorage } from "earthstar";
+import { sortByPublished, getLobbyDocPublishedTimestamp } from "./util/handy";
 
 function getLatestDocument(storage: IStorage) {
   return storage
     .documents({ pathPrefix: "/lobby/" })
-    .sort((aDoc, bDoc) => (aDoc.timestamp > bDoc.timestamp ? -1 : 1))
+    .sort(sortByPublished)
     .shift();
 }
 
@@ -37,7 +38,10 @@ const Dashboard = () => {
                 return -1;
               }
 
-              return aLatest?.timestamp > bLatest?.timestamp ? -1 : 1;
+              return getLobbyDocPublishedTimestamp(aLatest) >
+                getLobbyDocPublishedTimestamp(bLatest)
+                ? -1
+                : 1;
             })
             .map((storage) => {
               return (

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -1,14 +1,22 @@
 import React from "react";
 import { css } from "styled-components/macro";
 import WorkspaceSummary from "./WorkspaceSummary";
-import { useWorkspaces } from "react-earthstar";
+import { useStorages } from "react-earthstar";
+import { IStorage } from "earthstar";
+
+function getLatestDocument(storage: IStorage) {
+  return storage
+    .documents({ pathPrefix: "/lobby/" })
+    .sort((aDoc, bDoc) => (aDoc.timestamp > bDoc.timestamp ? -1 : 1))
+    .shift();
+}
 
 const Dashboard = () => {
-  const workspaces = useWorkspaces();
+  const [storages] = useStorages();
 
   return (
     <>
-      {workspaces.length > 0 ? (
+      {Object.values(storages).length > 0 ? (
         <ul
           css={css`
             margin: 1em 0 0 0;
@@ -16,18 +24,33 @@ const Dashboard = () => {
             animation-delay: 500ms;
           `}
         >
-          {workspaces.map((ws) => {
-            return (
-              <div
-                key={ws}
-                css={css`
-                  margin-bottom: 2em;
-                `}
-              >
-                <WorkspaceSummary workspace={ws} />
-              </div>
-            );
-          })}
+          {Object.values(storages)
+            .sort((aStorage, bStorage) => {
+              const aLatest = getLatestDocument(aStorage);
+              const bLatest = getLatestDocument(bStorage);
+
+              if (!aLatest) {
+                return 1;
+              }
+
+              if (!bLatest) {
+                return -1;
+              }
+
+              return aLatest?.timestamp > bLatest?.timestamp ? -1 : 1;
+            })
+            .map((storage) => {
+              return (
+                <div
+                  key={storage.workspace}
+                  css={css`
+                    margin-bottom: 2em;
+                  `}
+                >
+                  <WorkspaceSummary workspace={storage.workspace} />
+                </div>
+              );
+            })}
         </ul>
       ) : null}
     </>

--- a/src/WorkspaceMessages.tsx
+++ b/src/WorkspaceMessages.tsx
@@ -4,6 +4,7 @@ import { css } from "styled-components/macro";
 import MaxWidth from "./MaxWidth";
 import { useDocuments } from "react-earthstar";
 import { Document } from "earthstar";
+import { sortByPublished, getLobbyDocPublishedTimestamp } from "./util/handy";
 
 type WorkspaceMessagesProps = {
   workspace: string;
@@ -13,18 +14,16 @@ const WorkspaceMessages: React.FC<WorkspaceMessagesProps> = ({ workspace }) => {
   const documents = useDocuments({ pathPrefix: "/lobby/" }, workspace);
 
   // Partition the documents by day (local)
-  const docsByDate = documents
-    .sort((a, b) => (a.timestamp > b.timestamp ? -1 : 1))
-    .reduce((acc, doc) => {
-      const docDate = new Date(doc.timestamp / 1000);
-      const docDateString = docDate.toDateString();
-      const accDateCollection = acc[docDateString] || [];
+  const docsByDate = documents.sort(sortByPublished).reduce((acc, doc) => {
+    const docDate = new Date(getLobbyDocPublishedTimestamp(doc));
+    const docDateString = docDate.toDateString();
+    const accDateCollection = acc[docDateString] || [];
 
-      return {
-        ...acc,
-        [docDateString]: [...accDateCollection, doc],
-      };
-    }, {} as Record<string, Document[]>);
+    return {
+      ...acc,
+      [docDateString]: [...accDateCollection, doc],
+    };
+  }, {} as Record<string, Document[]>);
 
   return (
     <div>

--- a/src/WorkspaceSummary.tsx
+++ b/src/WorkspaceSummary.tsx
@@ -12,6 +12,7 @@ import {
   useStorage,
   AuthorLabel,
 } from "react-earthstar";
+import { sortByPublished } from "./util/handy";
 
 type WorkspaceSummaryProps = {
   workspace: string;
@@ -21,7 +22,7 @@ const WorkspaceSummary: React.FC<WorkspaceSummaryProps> = ({ workspace }) => {
   const { appStateDispatch } = useContext(LobbyContext);
 
   const firstThreePosts = useDocuments({ pathPrefix: "/lobby/" }, workspace)
-    .sort((aDoc, bDoc) => (aDoc.timestamp > bDoc.timestamp ? -1 : 0))
+    .sort(sortByPublished)
     .slice(0, 3);
 
   const storage = useStorage(workspace);

--- a/src/WorkspaceViewer.tsx
+++ b/src/WorkspaceViewer.tsx
@@ -2,9 +2,7 @@ import React from "react";
 import MessageComposer from "./MessageComposer";
 import WorkspaceMessages from "./WorkspaceMessages";
 import { useCurrentAuthor } from "react-earthstar";
-import Button from "./Button";
 import { LobbyContext } from "./util/lobby-context";
-import MaxWidth from "./MaxWidth";
 
 type WorkspaceViewerProps = {
   workspaceAddress: string;
@@ -14,7 +12,6 @@ const WorkspaceViewer: React.FC<WorkspaceViewerProps> = ({
   workspaceAddress,
 }) => {
   const [currentAuthor] = useCurrentAuthor();
-  const { appStateDispatch } = React.useContext(LobbyContext);
 
   return (
     <>

--- a/src/WorkspaceViewer.tsx
+++ b/src/WorkspaceViewer.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import MessageComposer from "./MessageComposer";
 import WorkspaceMessages from "./WorkspaceMessages";
 import { useCurrentAuthor } from "react-earthstar";
-import { LobbyContext } from "./util/lobby-context";
 
 type WorkspaceViewerProps = {
   workspaceAddress: string;

--- a/src/util/handy.ts
+++ b/src/util/handy.ts
@@ -1,4 +1,4 @@
-import { AuthorKeypair, ValidatorEs4 } from "earthstar";
+import { AuthorKeypair, ValidatorEs4, Document } from "earthstar";
 
 export function isKeypair(val: any): val is AuthorKeypair {
   if (!val.address || !val.secret) {
@@ -49,5 +49,25 @@ export function hexToRgb(hex: string) {
         b: parseInt(result[3], 16),
       }
     : { r: 0, g: 0, b: 0 };
+}
+
+const pathTimestampRegex = /(\d*)(?:\.txt)/
+
+
+export function getLobbyDocPublishedTimestamp(doc: Document): number {
+  const result = pathTimestampRegex.exec(doc.path);
+  
+  if (result === null) {
+    return 0
+  }
+  
+  return parseInt(result[0])
+}
+
+export function sortByPublished(docA: Document, docB: Document) {
+  const aTimestamp = getLobbyDocPublishedTimestamp(docA)
+  const bTimestamp = getLobbyDocPublishedTimestamp(docB);
+  
+  return aTimestamp > bTimestamp ? -1 : 1
 }
 


### PR DESCRIPTION
Sorts workspaces by most recently posted to, and messages by their date of publication rather than when their document was last written to.

Probably want to wait on deploying this until the react-earthstar localstorage fix comes in. 

Closes #3 